### PR TITLE
utils - Response Reader/Writer - fixes and additions:

### DIFF
--- a/utils/io/httputils/responsereaderwriter/responsewriter.go
+++ b/utils/io/httputils/responsereaderwriter/responsewriter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"io/ioutil"
 	"os"
+	"sync"
 )
 
 const (
@@ -21,7 +22,9 @@ type ResponseWriter struct {
 	outputFile *os.File
 	// The chanel which from the output records will be pulled.
 	recordsChannel chan interface{}
+	recordCount    int
 	errorsQueue    *utils.ErrorsQueue
+	runWaiter      sync.WaitGroup
 }
 
 func NewResponseWriter(chanCapacity int, arrayKey string) (*ResponseWriter, error) {
@@ -34,11 +37,16 @@ func NewResponseWriter(chanCapacity int, arrayKey string) (*ResponseWriter, erro
 	self.outputFile = fd
 	self.recordsChannel = make(chan interface{}, chanCapacity)
 	self.errorsQueue = utils.NewErrorsQueue(chanCapacity)
+	self.recordCount = 0
 	return &self, nil
 }
 
 func (rw *ResponseWriter) GetOutputFilePath() string {
 	return rw.outputFile.Name()
+}
+
+func (rw *ResponseWriter) GetRecordCount() int {
+	return rw.recordCount
 }
 
 func (rw *ResponseWriter) RemoveOutputFilePath() error {
@@ -47,9 +55,19 @@ func (rw *ResponseWriter) RemoveOutputFilePath() error {
 
 func (rw *ResponseWriter) AddRecord(record interface{}) {
 	rw.recordsChannel <- record
+	rw.recordCount++
 }
 
 func (rw *ResponseWriter) Run() {
+	rw.runWaiter.Add(1)
+	go func() {
+		defer rw.runWaiter.Done()
+		rw.run()
+	}()
+	return
+}
+
+func (rw *ResponseWriter) run() {
 	defer rw.outputFile.Close()
 	_, err := rw.outputFile.WriteString(fmt.Sprintf(jsonArrayPrefixPattern, rw.arrayKey))
 	if err != nil {
@@ -75,5 +93,6 @@ func (rw *ResponseWriter) Run() {
 
 func (rw *ResponseWriter) Stop() error {
 	close(rw.recordsChannel)
+	rw.runWaiter.Wait()
 	return rw.errorsQueue.GetError()
 }


### PR DESCRIPTION
    * Start a new goroutine in write's Run()
    * Add GetRecord() to reader to allow iterating over the file
    * Delete only file and not directory in reader's delete file method
    * Create a new map object for each send on the reader's channel
    * Add test for reader after writer